### PR TITLE
Improve block device detection for x86

### DIFF
--- a/META-INF/com/google/android/update-binary
+++ b/META-INF/com/google/android/update-binary
@@ -160,7 +160,11 @@ DYNAMIC_PARTITIONS=`getprop ro.boot.dynamic_partitions`
 if [ "$DYNAMIC_PARTITIONS" = "true" ]; then
     BLK_PATH="/dev/block/mapper"
 else
-    BLK_PATH=/dev/block/bootdevice/by-name
+    if [ -d /dev/block/by-name ]; then
+        BLK_PATH=/dev/block/by-name
+    else
+        BLK_PATH=/dev/block/bootdevice/by-name
+    fi
 fi
 
 CURRENTSLOT=`getprop ro.boot.slot_suffix`


### PR DESCRIPTION
## Summary
- detect `/dev/block/by-name` before assuming `/dev/block/bootdevice/by-name`

## Testing
- `shellcheck META-INF/com/google/android/update-binary`

------
https://chatgpt.com/codex/tasks/task_e_687bf4f961388325876e1754e84c6b6b